### PR TITLE
Add group habit detail pages and month calendar visualizations

### DIFF
--- a/app/habit-group/[templateKey]/page.tsx
+++ b/app/habit-group/[templateKey]/page.tsx
@@ -1,0 +1,390 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Habit, Event, User } from '@prisma/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { toast } from 'react-hot-toast'
+import Link from 'next/link'
+import { getHabitStats } from '@/lib/stats'
+import GroupMonthCalendar from '@/components/GroupMonthCalendar'
+
+interface HabitWithOwner extends Habit {
+  owner?: {
+    id: string
+    name: string
+    color?: string
+  }
+}
+
+interface GroupHabitData {
+  habits: HabitWithOwner[]
+  events: { [habitId: string]: Event[] }
+}
+
+export default function GroupHabitDetailPage({ params }: { params: { templateKey: string } }) {
+  const [groupData, setGroupData] = useState<GroupHabitData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchGroupHabitData()
+  }, [params.templateKey])
+
+  const fetchGroupHabitData = async () => {
+    try {
+      const habitsRes = await fetch('/api/habits')
+      const allHabits = await habitsRes.json()
+      
+      const groupHabits = allHabits.filter((h: any) => 
+        h.templateKey === params.templateKey && h.visibility === 'household'
+      )
+      
+      if (groupHabits.length === 0) {
+        setGroupData(null)
+        setLoading(false)
+        return
+      }
+
+      const eventPromises = groupHabits.map(async (habit: Habit) => {
+        const res = await fetch(`/api/habits/${habit.id}/events`)
+        const events = await res.json()
+        return { habitId: habit.id, events }
+      })
+      
+      const results = await Promise.all(eventPromises)
+      const eventsMap: { [habitId: string]: Event[] } = {}
+      
+      results.forEach(({ habitId, events }) => {
+        eventsMap[habitId] = events
+      })
+      
+      setGroupData({
+        habits: groupHabits,
+        events: eventsMap
+      })
+    } catch (error) {
+      console.error('Failed to fetch group habit data:', error)
+      toast.error('Failed to load group habit data')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleVoidEvent = async (eventId: string) => {
+    try {
+      const res = await fetch(`/api/events/${eventId}/void`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          reason: 'mistap',
+        }),
+      })
+
+      if (res.ok) {
+        fetchGroupHabitData()
+        toast.success('Event undone successfully!')
+      } else {
+        toast.error('Failed to undo event')
+      }
+    } catch (error) {
+      console.error('Failed to void event:', error)
+      toast.error('Failed to undo event')
+    }
+  }
+
+  const handleQuickLog = async (habitId: string, userName: string) => {
+    try {
+      const response = await fetch(`/api/habits/${habitId}/events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          value: 1,
+          source: 'ui',
+          date: new Date().toISOString().split('T')[0]
+        }),
+      })
+
+      if (response.ok) {
+        toast.success(`Logged for ${userName}!`)
+        fetchGroupHabitData()
+      } else {
+        toast.error('Failed to log event')
+      }
+    } catch (error) {
+      toast.error('Failed to log event')
+    }
+  }
+
+  if (loading) {
+    return <div className="container mx-auto p-4">Loading...</div>
+  }
+
+  if (!groupData || groupData.habits.length === 0) {
+    return (
+      <div className="container mx-auto p-4">
+        <div className="flex items-center justify-between mb-4">
+          <Link href="/today" className="text-blue-500 hover:underline">
+            ← Back to Today
+          </Link>
+        </div>
+        <p>Group habit not found</p>
+      </div>
+    )
+  }
+
+  const primaryHabit = groupData.habits[0]
+  const habitName = primaryHabit.name
+  const habitEmoji = primaryHabit.emoji || '🎯'
+
+  const periodLabel = {
+    day: 'per day',
+    week: 'per week',
+    month: 'per month',
+    custom: 'per period'
+  }[primaryHabit.period] || 'per period'
+
+  const unitDisplay = primaryHabit.unit === 'custom' && primaryHabit.unitLabel 
+    ? primaryHabit.unitLabel 
+    : primaryHabit.unit === 'minutes' 
+      ? 'minutes' 
+      : ''
+
+  return (
+    <div className="container mx-auto p-4 max-w-4xl">
+      <div className="flex items-center justify-between mb-4">
+        <Link href="/today" className="text-blue-500 hover:underline">
+          ← Back to Today
+        </Link>
+      </div>
+      
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            {habitEmoji && <span className="text-3xl">{habitEmoji}</span>}
+            <span>{habitName}</span>
+            <span className="ml-2 px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-sm">
+              Household Habit
+            </span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+            <div>
+              <p className="text-sm text-gray-500">Type</p>
+              <p className="font-medium">{primaryHabit.type === 'build' ? '📈 Build' : '🚫 Break'}</p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">Target</p>
+              <p className="font-medium">
+                {primaryHabit.target} {unitDisplay} {periodLabel}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm text-gray-500">Members</p>
+              <p className="font-medium">{groupData.habits.length} people</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Member Progress</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {groupData.habits.map((habit) => {
+              const events = groupData.events[habit.id] || []
+              const stats = getHabitStats(habit, events, 'America/New_York', 'MON')
+              const progressPercentage = habit.type === 'build' 
+                ? Math.min(100, (stats.currentPeriodProgress / habit.target) * 100)
+                : 0
+
+              const userColor = habit.owner?.color || '#64748b'
+              const userName = habit.owner?.name || 'Unknown User'
+              const userInitials = userName.split(' ').map(n => n[0]).join('').toUpperCase()
+
+              return (
+                <div key={habit.id} className="flex items-center space-x-3 p-3 border rounded-lg">
+                  <div 
+                    className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium text-white flex-shrink-0"
+                    style={{ backgroundColor: userColor }}
+                  >
+                    {userInitials}
+                  </div>
+
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="font-medium text-slate-700">{userName}</span>
+                      <div className="flex items-center gap-4">
+                        <span className="text-sm text-slate-500">
+                          {stats.currentPeriodProgress}
+                          {habit.type === 'build' && `/${habit.target}`}
+                          {unitDisplay && ` ${unitDisplay}`}
+                        </span>
+                        {habit.type === 'build' ? (
+                          <span className={`text-xs px-2 py-1 rounded-full ${
+                            stats.isOnPace 
+                              ? 'bg-emerald-100 text-emerald-700' 
+                              : 'bg-amber-100 text-amber-700'
+                          }`}>
+                            {stats.isOnPace ? 'On track' : 'At risk'}
+                          </span>
+                        ) : (
+                          <span className={`text-xs px-2 py-1 rounded-full ${
+                            stats.timeSinceLastFailure === 0
+                              ? 'bg-red-100 text-red-700'
+                              : 'bg-emerald-100 text-emerald-700'
+                          }`}>
+                            {stats.timeSinceLastFailure || 0} days clean
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1">
+                        <div className="w-full bg-slate-200 rounded-full h-2">
+                          <div 
+                            className="h-2 rounded-full transition-all duration-300"
+                            style={{ 
+                              width: `${Math.min(100, progressPercentage)}%`,
+                              backgroundColor: progressPercentage >= 100 ? '#10b981' : userColor 
+                            }}
+                          />
+                        </div>
+                      </div>
+
+                      <button
+                        onClick={() => handleQuickLog(habit.id, userName)}
+                        className="w-8 h-8 bg-blue-500 hover:bg-blue-600 text-white rounded-full flex items-center justify-center transition-all duration-200 hover:scale-105"
+                      >
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                        </svg>
+                      </button>
+                    </div>
+
+                    <div className="mt-2 flex items-center gap-4 text-sm text-gray-500">
+                      <span>🔥 {stats.streak} day streak</span>
+                      <span>📊 {Math.round(stats.adherenceRate)}% adherence</span>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="mt-4 pt-4 border-t">
+            <div className="flex justify-between text-sm">
+              <span className="text-slate-500">Total Progress</span>
+              <span className="font-medium text-slate-700">
+                {groupData.habits.reduce((total, habit) => {
+                  const events = groupData.events[habit.id] || []
+                  const stats = getHabitStats(habit, events, 'America/New_York', 'MON')
+                  return total + stats.currentPeriodProgress
+                }, 0)} {unitDisplay}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Monthly Overview</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <GroupMonthCalendar 
+            habits={groupData.habits} 
+            eventsMap={groupData.events}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Group Activity</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {(() => {
+            const allEvents: Array<{event: Event, habitId: string, userName: string, userColor: string}> = []
+            
+            groupData.habits.forEach(habit => {
+              const events = groupData.events[habit.id] || []
+              events.forEach(event => {
+                if (!(event.meta && typeof event.meta === 'object' && 'kind' in event.meta && event.meta.kind === 'void')) {
+                  allEvents.push({
+                    event,
+                    habitId: habit.id,
+                    userName: habit.owner?.name || 'Unknown',
+                    userColor: habit.owner?.color || '#64748b'
+                  })
+                }
+              })
+            })
+
+            allEvents.sort((a, b) => 
+              new Date(b.event.tsClient).getTime() - new Date(a.event.tsClient).getTime()
+            )
+
+            const recentEvents = allEvents.slice(0, 10)
+
+            if (recentEvents.length === 0) {
+              return <p className="text-gray-500">No events yet</p>
+            }
+
+            return (
+              <ul className="space-y-2">
+                {recentEvents.map(({ event, habitId, userName, userColor }) => {
+                  const isVoided = groupData.habits.some(h => 
+                    (groupData.events[h.id] || []).some(e => 
+                      e.meta && 
+                      typeof e.meta === 'object' && 
+                      'void_of' in e.meta && 
+                      e.meta.void_of === event.id
+                    )
+                  )
+
+                  return (
+                    <li key={event.id} className="flex justify-between items-center border-b pb-2">
+                      <div className="flex items-center gap-3">
+                        <div 
+                          className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white"
+                          style={{ backgroundColor: userColor }}
+                        >
+                          {userName.split(' ').map(n => n[0]).join('').toUpperCase()}
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium">{userName}</p>
+                          <p className="text-xs text-gray-500">
+                            {new Date(event.tsClient).toLocaleString()} • {event.value} {unitDisplay}
+                          </p>
+                          {event.note && <p className="text-xs text-gray-500">Note: {event.note}</p>}
+                          {isVoided && <p className="text-xs text-red-500">Corrected</p>}
+                        </div>
+                      </div>
+                      {!isVoided && (
+                        <Button 
+                          variant="outline" 
+                          size="sm"
+                          onClick={() => handleVoidEvent(event.id)}
+                        >
+                          Undo
+                        </Button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            )
+          })()}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/habit/[id]/page.tsx
+++ b/app/habit/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { toast } from 'react-hot-toast'
 import Link from 'next/link'
 import { getHabitStats } from '@/lib/stats'
+import MonthCalendar from '@/components/MonthCalendar'
 
 export default function HabitDetailPage({ params }: { params: { id: string } }) {
   const [habit, setHabit] = useState<Habit | null>(null)
@@ -159,6 +160,15 @@ export default function HabitDetailPage({ params }: { params: { id: string } }) 
               </div>
             )
           })()}
+        </CardContent>
+      </Card>
+
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Monthly Overview</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <MonthCalendar habit={habit} events={events} />
         </CardContent>
       </Card>
 

--- a/components/GroupMonthCalendar.tsx
+++ b/components/GroupMonthCalendar.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Habit, Event } from '@prisma/client'
+import { getHabitStats } from '@/lib/stats'
+
+interface HabitWithOwner extends Habit {
+  owner?: {
+    id: string
+    name: string
+    color?: string
+  }
+}
+
+interface GroupMonthCalendarProps {
+  habits: HabitWithOwner[]
+  eventsMap: { [habitId: string]: Event[] }
+  currentUserId?: string
+  month?: string // YYYY-MM format
+}
+
+export default function GroupMonthCalendar({ 
+  habits, 
+  eventsMap, 
+  currentUserId,
+  month 
+}: GroupMonthCalendarProps) {
+  const [currentMonth, setCurrentMonth] = useState<string>(() => {
+    if (month) return month
+    const now = new Date()
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  })
+
+  const [calendarDays, setCalendarDays] = useState<Array<{
+    date: string
+    day: number
+    isCurrentMonth: boolean
+    completions: Array<{
+      userId: string
+      userName: string
+      userColor: string
+      value: number
+      isComplete: boolean
+    }>
+    totalCompletions: number
+    currentUserCompleted: boolean
+  }>>([])
+
+  const primaryHabit = habits[0]
+  if (!primaryHabit) return null
+
+  useEffect(() => {
+    generateCalendarDays()
+  }, [currentMonth, eventsMap])
+
+  const generateCalendarDays = () => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const firstDay = new Date(year, month - 1, 1)
+    const lastDay = new Date(year, month, 0)
+    
+    // Get the first Monday before or on the first day of the month
+    const startDate = new Date(firstDay)
+    const dayOfWeek = startDate.getDay()
+    const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+    startDate.setDate(startDate.getDate() - daysToMonday)
+    
+    const days: typeof calendarDays = []
+    const currentDate = new Date(startDate)
+    
+    // Generate 6 weeks of days (42 days total)
+    for (let i = 0; i < 42; i++) {
+      const dateString = currentDate.toISOString().split('T')[0]
+      const dayCompletions: typeof calendarDays[0]['completions'] = []
+      
+      habits.forEach(habit => {
+        const events = eventsMap[habit.id] || []
+        const dayEvents = events.filter(e => {
+          const eventDate = new Date(e.tsClient).toISOString().split('T')[0]
+          return eventDate === dateString && 
+            !(e.meta && typeof e.meta === 'object' && 'kind' in e.meta && e.meta.kind === 'void')
+        })
+        
+        const totalValue = dayEvents.reduce((sum, e) => sum + e.value, 0)
+        const isComplete = primaryHabit.type === 'build' 
+          ? totalValue >= habit.target 
+          : dayEvents.length === 0
+        
+        if (dayEvents.length > 0 || (primaryHabit.type === 'break' && currentDate <= new Date())) {
+          dayCompletions.push({
+            userId: habit.owner?.id || '',
+            userName: habit.owner?.name || 'Unknown',
+            userColor: habit.owner?.color || '#64748b',
+            value: totalValue,
+            isComplete
+          })
+        }
+      })
+      
+      const totalCompletions = dayCompletions.filter(c => c.isComplete).length
+      const currentUserCompleted = dayCompletions.some(c => c.userId === currentUserId && c.isComplete)
+      
+      days.push({
+        date: dateString,
+        day: currentDate.getDate(),
+        isCurrentMonth: currentDate.getMonth() === month - 1,
+        completions: dayCompletions,
+        totalCompletions,
+        currentUserCompleted
+      })
+      
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+    
+    setCalendarDays(days)
+  }
+
+  const navigateMonth = (direction: 'prev' | 'next') => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const newDate = new Date(year, month - 1 + (direction === 'next' ? 1 : -1), 1)
+    setCurrentMonth(`${newDate.getFullYear()}-${String(newDate.getMonth() + 1).padStart(2, '0')}`)
+  }
+
+  const getMonthYearDisplay = () => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const date = new Date(year, month - 1)
+    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  }
+
+  const isToday = (dateStr: string) => {
+    return dateStr === new Date().toISOString().split('T')[0]
+  }
+
+  const getDayColor = (day: typeof calendarDays[0]) => {
+    if (!day.isCurrentMonth) return 'bg-gray-50 text-gray-400'
+    
+    const maxCompletions = habits.length
+    const completionRatio = day.totalCompletions / maxCompletions
+    
+    if (day.totalCompletions === 0) return 'bg-white hover:bg-gray-50'
+    
+    // Color intensity based on number of completions
+    if (completionRatio === 1) return 'bg-green-600 text-white'
+    if (completionRatio >= 0.75) return 'bg-green-500 text-white'
+    if (completionRatio >= 0.5) return 'bg-green-400 text-white'
+    if (completionRatio >= 0.25) return 'bg-green-300 text-gray-800'
+    return 'bg-green-200 text-gray-800'
+  }
+
+  const getDayBorder = (day: typeof calendarDays[0]) => {
+    if (!day.isCurrentMonth) return ''
+    if (day.currentUserCompleted) return 'ring-2 ring-blue-500 ring-inset'
+    return ''
+  }
+
+  const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">Group Activity Calendar</h3>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigateMonth('prev')}
+            className="p-1 hover:bg-gray-100 rounded"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <span className="text-sm font-medium min-w-[120px] text-center">
+            {getMonthYearDisplay()}
+          </span>
+          <button
+            onClick={() => navigateMonth('next')}
+            className="p-1 hover:bg-gray-100 rounded"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* User legend */}
+      <div className="mb-4 p-3 bg-gray-50 rounded-lg">
+        <div className="flex flex-wrap items-center gap-3 text-sm">
+          <span className="font-medium text-gray-700">Members:</span>
+          {habits.map(habit => (
+            <div key={habit.id} className="flex items-center gap-1">
+              <div 
+                className="w-4 h-4 rounded-full"
+                style={{ backgroundColor: habit.owner?.color || '#64748b' }}
+              />
+              <span className="text-gray-600">{habit.owner?.name || 'Unknown'}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {weekDays.map(day => (
+          <div key={day} className="text-center text-xs font-medium text-gray-500 py-1">
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-1">
+        {calendarDays.map((day, index) => (
+          <div
+            key={index}
+            className={`
+              aspect-square flex flex-col items-center justify-center rounded-md transition-all relative
+              ${getDayColor(day)}
+              ${getDayBorder(day)}
+              ${isToday(day.date) ? 'ring-2 ring-offset-2 ring-black' : ''}
+              ${day.isCurrentMonth ? 'cursor-pointer' : ''}
+            `}
+            title={day.isCurrentMonth ? `${day.date}: ${day.totalCompletions}/${habits.length} completed` : ''}
+          >
+            <span className="text-sm font-medium">{day.day}</span>
+            
+            {/* Completion indicator */}
+            {day.isCurrentMonth && day.totalCompletions > 0 && (
+              <div className="flex items-center gap-0.5 mt-1">
+                {day.completions.map((completion, idx) => (
+                  <div
+                    key={idx}
+                    className="w-1.5 h-1.5 rounded-full"
+                    style={{ 
+                      backgroundColor: completion.isComplete ? completion.userColor : 'transparent',
+                      border: completion.isComplete ? 'none' : `1px solid ${completion.userColor}`
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+            
+            {/* Current user indicator */}
+            {day.isCurrentMonth && day.currentUserCompleted && (
+              <div className="absolute top-1 right-1">
+                <svg className="w-3 h-3 text-white drop-shadow" fill="currentColor" viewBox="0 0 20 20">
+                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                </svg>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 space-y-2">
+        <div className="flex items-center justify-center gap-4 text-xs text-gray-600">
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 bg-green-600 rounded"></div>
+            <span>All completed</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 bg-green-400 rounded"></div>
+            <span>Partial</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 bg-white border border-gray-300 rounded"></div>
+            <span>None</span>
+          </div>
+        </div>
+        <div className="flex items-center justify-center gap-4 text-xs text-gray-600">
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 border-2 border-blue-500 rounded"></div>
+            <span>You completed</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 border-2 border-black rounded"></div>
+            <span>Today</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/MergedHabitCard.tsx
+++ b/components/MergedHabitCard.tsx
@@ -5,6 +5,7 @@ import { Habit, Event } from '@prisma/client'
 import { toast } from 'react-hot-toast'
 import { getHabitStats } from '@/lib/stats'
 import { getCurrentPeriod } from '@/lib/period'
+import Link from 'next/link'
 
 interface HabitWithOwner extends Habit {
   events?: Event[]
@@ -76,7 +77,8 @@ export default function MergedHabitCard({
       : ''
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 hover:shadow-md transition-all duration-200">
+    <Link href={`/habit-group/${templateKey}`} className="block">
+      <div className="bg-white rounded-2xl shadow-sm border border-slate-200 p-6 hover:shadow-md transition-all duration-200 hover:scale-[1.01] cursor-pointer">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center space-x-3">
@@ -151,7 +153,9 @@ export default function MergedHabitCard({
 
               {/* Quick log button */}
               <button
-                onClick={async () => {
+                onClick={async (e) => {
+                  e.preventDefault() // Prevent link navigation
+                  e.stopPropagation() // Stop event bubbling to Link
                   try {
                     const response = await fetch(`/api/habits/${habit.id}/events`, {
                       method: 'POST',
@@ -203,5 +207,6 @@ export default function MergedHabitCard({
         </div>
       </div>
     </div>
+    </Link>
   )
 }

--- a/components/MonthCalendar.tsx
+++ b/components/MonthCalendar.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { Habit, Event } from '@prisma/client'
+import { getHabitStats } from '@/lib/stats'
+
+interface MonthCalendarProps {
+  habit: Habit
+  events: Event[]
+  month?: string // YYYY-MM format
+}
+
+export default function MonthCalendar({ habit, events, month }: MonthCalendarProps) {
+  const [currentMonth, setCurrentMonth] = useState<string>(() => {
+    if (month) return month
+    const now = new Date()
+    return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  })
+
+  const [calendarDays, setCalendarDays] = useState<Array<{
+    date: string
+    day: number
+    isCurrentMonth: boolean
+    hasEvent: boolean
+    isComplete: boolean
+    eventCount: number
+    totalValue: number
+  }>>([])
+
+  useEffect(() => {
+    generateCalendarDays()
+  }, [currentMonth, events])
+
+  const generateCalendarDays = () => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const firstDay = new Date(year, month - 1, 1)
+    const lastDay = new Date(year, month, 0)
+    
+    // Get the first Monday before or on the first day of the month
+    const startDate = new Date(firstDay)
+    const dayOfWeek = startDate.getDay()
+    const daysToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1
+    startDate.setDate(startDate.getDate() - daysToMonday)
+    
+    const days: typeof calendarDays = []
+    const currentDate = new Date(startDate)
+    
+    // Generate 6 weeks of days (42 days total)
+    for (let i = 0; i < 42; i++) {
+      const dateString = currentDate.toISOString().split('T')[0]
+      const dayEvents = events.filter(e => {
+        const eventDate = new Date(e.tsClient).toISOString().split('T')[0]
+        return eventDate === dateString && 
+          !(e.meta && typeof e.meta === 'object' && 'kind' in e.meta && e.meta.kind === 'void')
+      })
+      
+      const totalValue = dayEvents.reduce((sum, e) => sum + e.value, 0)
+      const isComplete = habit.type === 'build' 
+        ? totalValue >= habit.target 
+        : dayEvents.length === 0
+      
+      days.push({
+        date: dateString,
+        day: currentDate.getDate(),
+        isCurrentMonth: currentDate.getMonth() === month - 1,
+        hasEvent: dayEvents.length > 0,
+        isComplete,
+        eventCount: dayEvents.length,
+        totalValue
+      })
+      
+      currentDate.setDate(currentDate.getDate() + 1)
+    }
+    
+    setCalendarDays(days)
+  }
+
+  const navigateMonth = (direction: 'prev' | 'next') => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const newDate = new Date(year, month - 1 + (direction === 'next' ? 1 : -1), 1)
+    setCurrentMonth(`${newDate.getFullYear()}-${String(newDate.getMonth() + 1).padStart(2, '0')}`)
+  }
+
+  const getMonthYearDisplay = () => {
+    const [year, month] = currentMonth.split('-').map(Number)
+    const date = new Date(year, month - 1)
+    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  }
+
+  const isToday = (dateStr: string) => {
+    return dateStr === new Date().toISOString().split('T')[0]
+  }
+
+  const getDayColor = (day: typeof calendarDays[0]) => {
+    if (!day.isCurrentMonth) return 'bg-gray-50 text-gray-400'
+    
+    if (habit.type === 'build') {
+      if (!day.hasEvent) return 'bg-white hover:bg-gray-50'
+      if (day.isComplete) return 'bg-green-500 text-white'
+      const progress = (day.totalValue / habit.target) * 100
+      if (progress >= 75) return 'bg-green-400 text-white'
+      if (progress >= 50) return 'bg-green-300 text-gray-800'
+      if (progress >= 25) return 'bg-green-200 text-gray-800'
+      return 'bg-green-100 text-gray-800'
+    } else {
+      // Break habits
+      if (day.hasEvent) return 'bg-red-500 text-white'
+      return 'bg-green-500 text-white'
+    }
+  }
+
+  const weekDays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+  return (
+    <div className="w-full">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">Activity Calendar</h3>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => navigateMonth('prev')}
+            className="p-1 hover:bg-gray-100 rounded"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <span className="text-sm font-medium min-w-[120px] text-center">
+            {getMonthYearDisplay()}
+          </span>
+          <button
+            onClick={() => navigateMonth('next')}
+            className="p-1 hover:bg-gray-100 rounded"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {weekDays.map(day => (
+          <div key={day} className="text-center text-xs font-medium text-gray-500 py-1">
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 gap-1">
+        {calendarDays.map((day, index) => (
+          <div
+            key={index}
+            className={`
+              aspect-square flex flex-col items-center justify-center rounded-md transition-colors
+              ${getDayColor(day)}
+              ${isToday(day.date) ? 'ring-2 ring-blue-500 ring-offset-1' : ''}
+              ${day.isCurrentMonth ? 'cursor-pointer' : ''}
+            `}
+            title={day.isCurrentMonth ? `${day.date}: ${day.totalValue} ${habit.unitLabel || habit.unit || ''}` : ''}
+          >
+            <span className="text-sm font-medium">{day.day}</span>
+            {day.isCurrentMonth && day.hasEvent && habit.type === 'build' && (
+              <span className="text-xs mt-0.5">
+                {day.totalValue}/{habit.target}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="mt-4 flex items-center justify-center gap-4 text-xs text-gray-600">
+        <div className="flex items-center gap-1">
+          <div className="w-4 h-4 bg-green-500 rounded"></div>
+          <span>{habit.type === 'build' ? 'Complete' : 'Clean'}</span>
+        </div>
+        {habit.type === 'build' && (
+          <>
+            <div className="flex items-center gap-1">
+              <div className="w-4 h-4 bg-green-300 rounded"></div>
+              <span>Partial</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <div className="w-4 h-4 bg-white border border-gray-300 rounded"></div>
+              <span>No activity</span>
+            </div>
+          </>
+        )}
+        {habit.type === 'break' && (
+          <div className="flex items-center gap-1">
+            <div className="w-4 h-4 bg-red-500 rounded"></div>
+            <span>Incident</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Added clickable detail pages for group habits
- Integrated month calendar visualizations for both single-user and multi-user habits
- Enhanced habit tracking with visual completion patterns

## Changes

### Group Habit Detail Pages
- Created new route `/habit-group/[templateKey]` for group habit details
- Updated `MergedHabitCard` component to be clickable and link to detail pages
- Shows member progress, stats, and recent activity for the entire group

### Calendar Visualizations

#### Single-User Habits
- Added `MonthCalendar` component with color-coded daily completion squares
- Green intensity shows completion level for build habits
- Red indicates break habit incidents
- Integrated into existing `/habit/[id]` pages

#### Multi-User Habits  
- Created `GroupMonthCalendar` component for household habits
- Color intensity indicates number of members who completed
- Blue border highlights days where current user participated
- Includes member legend with avatars and colors

## Test Plan
- [x] Build completes successfully
- [ ] Navigate to group habit from dashboard
- [ ] View month calendar on single-user habit detail page
- [ ] View group calendar with multi-user participation
- [ ] Test month navigation controls
- [ ] Verify quick log buttons still work
- [ ] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)